### PR TITLE
Fixed some issues to do with logging level

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,11 @@ Or if you are in developmet and would like to have all instances of Logplexer be
 
 and everything that isn't specifically marked as `verbose: false` will print the backtrace. Keep in mind that verbose only works when the input is an Exception type.
 
+
+Likewise, if you are in development or test and would like to quiet all logs ( i.e. don't report any Logplexer errors ), just set `LOG_QUIET` to 'true':
+
+    ENV['LOG_QUIET'] = "true"
+
 ## Configuration
 
 If your `RAILS_ENV` is set to `development` or `test`, Logplexer will set an environment variable called `LOG_TO_HB` as "false" if it is anything else, i.e. `production` or `staging`, `LOG_TO_HB` will be set to "true".
@@ -104,6 +109,12 @@ or
 
     ENV['LOG_TO_HB'] = "false"
 
+### Overriding log level
+
+By default Logplexer will (as of version 0.2.0) log to Honeybadger only those errors with the log level of `error` or `fatal`. If you would like to adjust this, for example to log errors that are at or above  `warn` for instance, just put this line in your: `config/initializers/logplexer.rb`:
+
+    ENV['LOG_MIN_HB'] = 'warn' # could also be debug, info, error or fatal
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake rspec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
@@ -112,7 +123,7 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/[USERNAME]/logplexer.
+Bug reports and pull requests are welcome on GitHub at https://github.com/Fullscreen/logplexer.
 
 
 ## License

--- a/bin/console
+++ b/bin/console
@@ -10,5 +10,5 @@ require "logplexer"
 # require "pry"
 # Pry.start
 
-require "irb"
-IRB.start
+require "pry"
+Pry.start

--- a/lib/logplexer.rb
+++ b/lib/logplexer.rb
@@ -15,19 +15,19 @@ module Logplexer
     RUBY
   end
 
-  def log( exception, log_type, opts = {})
+  def log( exception, log_level, opts = {})
     # We wrap the Honeybadger notify call so that in development,
     # we actually see the errors. Then we can unwrap the REST errors
     # if need be
     return if exception.nil?
+    return if ENV['LOG_QUIET'] == 'true'
 
     logfile = opts.delete( :logfile )
     logger = Logger.new( logfile || STDOUT )
 
     # Override the verbosity if LOG_VERBOSE is unset
     verbose = ENV["LOG_VERBOSE"] == "true" ? true : opts.delete( :verbose )
-
-    if ENV['LOG_TO_HB'] == "true"
+    if ENV['LOG_TO_HB'] == "true" && above_min_log_level?( log_level )
       #TODO: Maybe extend this to include other kinds of notifiers.
       if exception.is_a? String
         exception = { error_class: "Exception",
@@ -38,21 +38,32 @@ module Logplexer
       # Make sure that the exception is an actual exception and
       # not just a hash since Honeybadger accepts both
       if exception.is_a? Exception
-        logger.send( log_type, exception.message )
+        logger.send( log_level, exception.message )
         if verbose
           exception.backtrace.each do |entry|
-            logger.send( log_type, "> #{entry}" )
+            logger.send( log_level, "> #{entry}" )
           end
         end
 
       elsif exception.is_a? String
         # Log just the string if thats what the user wants
-        logger.send( log_type, exception )
+        logger.send( log_level, exception )
 
       else
         # Default kind of log for an object or whatevs
-        logger.send( log_type, exception.inspect )
+        logger.send( log_level, exception.inspect )
       end
     end
   end
+
+  def above_min_log_level?( p )
+    min = ENV["LOG_MIN_HB"] || 'error'
+    return priority( p ) >= priority( min )
+  end
+
+  def priority( level )
+    @priorities ||= { debug: 0, info: 1, warn: 2, error: 3, fatal: 4 }
+    @priorities[ level.to_sym ]
+  end
+
 end

--- a/lib/logplexer/version.rb
+++ b/lib/logplexer/version.rb
@@ -1,3 +1,3 @@
 module Logplexer
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end

--- a/logplexer.gemspec
+++ b/logplexer.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.10"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec"
+  spec.add_development_dependency "pry"
   spec.add_development_dependency "webmock"
   spec.add_development_dependency "vcr"
 


### PR DESCRIPTION
This PR fixes issues [2](https://github.com/Fullscreen/logplexer/issues/2) and [3](https://github.com/Fullscreen/logplexer/issues/3)

- [x] Added Pry to console
- [x] Updated tests to new `expect` syntax
- [x] Added stubs for Logger to quiet logging to stdout in test
- [x] Updated README.md to have the right user name as @dstokes pointed
	out
- [x] Added a feature that allows users to select the min log level to
	post to Honeybadger so they can use `Logplexer.info` to log to STDOUT
	even in prod or whatever.
- [x] Added a LOG_QUIET option for the environment to allow users to
	quiet all logs on the fly
- [x] Added tests for new features
- [x] Bumped version to 0.2.0
- [x] Updated README to include recent changes.